### PR TITLE
Use `OptionParser` to parse Curl command in macro

### DIFF
--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -15,8 +15,8 @@ defmodule CurlReq.Macro do
       command
       |> OptionParser.split()
       |> OptionParser.parse(
-        strict: [header: :keep, method: :string, body: :string],
-        aliases: [H: :header, X: :method, d: :body]
+        strict: [header: :keep, request: :string, body: :string],
+        aliases: [H: :header, X: :request, d: :body]
       )
 
     url = String.trim(url)
@@ -48,7 +48,7 @@ defmodule CurlReq.Macro do
   defp add_method(req, options) do
     method =
       options
-      |> Keyword.get(:method, "GET")
+      |> Keyword.get(:request, "GET")
       |> String.downcase()
       |> String.to_existing_atom()
 

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -1,108 +1,62 @@
 defmodule CurlReq.Macro do
   @moduledoc false
 
-  def parse(string, acc \\ []) do
-    case do_parse(string) do
-      {out, rest} -> parse(rest, [out | acc])
-      out -> [out | acc] |> Enum.filter(& &1) |> Enum.reverse()
-    end
-  end
+  # TODO: handle newlines
+  # TODO: support -b (cookies)
+  # TODO: support multiple -d
 
-  def do_parse(string, state \\ :nothing, accumulator \\ "")
+  def parse(command) do
+    command =
+      command
+      |> String.trim()
+      |> String.trim_leading("curl")
 
-  #
-  # TODO handle newlines
-  #
-  # def do_parse("\n" <> rest, state, acc) do
-  #   do_parse(rest, state, acc)
-  # end
-  #
+    {options, [url], _invalid} =
+      command
+      |> OptionParser.split()
+      |> OptionParser.parse(
+        strict: [header: :keep, method: :string, body: :string],
+        aliases: [H: :header, X: :method, d: :body]
+      )
 
-  def do_parse(~S(") <> rest, :nothing, acc) do
-    do_parse(rest, :double_quote, acc)
-  end
-
-  def do_parse(~S(") <> rest, :double_quote, acc) do
-    do_parse(rest, :nothing, acc)
-  end
-
-  def do_parse(~S(') <> rest, :nothing, acc) do
-    do_parse(rest, :single_quote, acc)
-  end
-
-  def do_parse(~S(') <> rest, :single_quote, acc) do
-    do_parse(rest, :nothing, acc)
-  end
-
-  def do_parse(<<"\\", escaped>> <> rest, state, acc) when state in [:double_quote, :nothing] do
-    do_parse(rest, state, [escaped | acc])
-  end
-
-  def do_parse(" " <> rest, :double_quote, acc) do
-    do_parse(rest, :double_quote, [" " | acc])
-  end
-
-  def do_parse(" " <> rest, :nothing, acc) do
-    emit(acc, rest)
-    # do_parse(rest, :nothing, "")
-  end
-
-  def do_parse(<<byte, rest::binary>>, state, acc) do
-    do_parse(rest, state, [<<byte>> | acc])
-  end
-
-  def do_parse("", _state, acc) do
-    emit(acc, "")
-  end
-
-  def emit(acc, rest) do
-    out =
-      IO.iodata_to_binary(acc)
-      |> String.reverse()
-
-    case {out, rest} do
-      {"", ""} -> nil
-      {"", rest} -> {nil, rest}
-      {out, ""} -> out
-      {out, rest} -> {out, rest}
-    end
-  end
-
-  #
-  # TODO support -b (cookies)
-  #
-  # results in header `Cookie` with subsequent cookies separated by `; `
-  #
-
-  @doc false
-  def to_req(["curl" | rest]) do
-    to_req(rest, %Req.Request{})
+    url = String.trim(url)
+    %{url: url, options: options}
   end
 
   @doc false
-  def to_req(["-H", header | rest], req) do
-    [key, value] = String.split(header, ":", parts: 2)
-    new_req = Req.Request.put_header(req, String.trim(key), String.trim(value))
-    to_req(rest, new_req)
+  def to_req(%{url: url, options: options}) do
+    %Req.Request{}
+    |> Req.merge(url: url)
+    |> add_header(options)
+    |> add_method(options)
+    |> add_body(options)
   end
 
-  def to_req(["-X", method | rest], req) do
-    new_req = Req.merge(req, method: method)
-    to_req(rest, new_req)
+  defp add_header(req, options) do
+    headers = Keyword.get_values(options, :header)
+
+    for header <- headers, reduce: req do
+      req ->
+        [key, value] =
+          header
+          |> String.split(":", parts: 2)
+
+        Req.Request.put_header(req, String.trim(key), String.trim(value))
+    end
   end
 
-  #
-  # TODO support multiple -d
-  #
-  def to_req(["-d", body | rest], req) do
-    new_req = Req.merge(req, body: body)
-    to_req(rest, new_req)
+  defp add_method(req, options) do
+    method =
+      options
+      |> Keyword.get(:method, "GET")
+      |> String.downcase()
+      |> String.to_existing_atom()
+
+    Req.merge(req, method: method)
   end
 
-  def to_req([url | rest], req) do
-    new_req = Req.merge(req, url: url)
-    to_req(rest, new_req)
+  defp add_body(req, options) do
+    body = Keyword.get(options, :body)
+    Req.merge(req, body: body)
   end
-
-  def to_req([], req), do: req
 end

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -36,5 +36,13 @@ defmodule CurlReqTest do
                    "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"3544VE\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to Aureliahof16, Utrecht, The Netherlands.\"}}],\"formId\":4318}"
                }
     end
+
+    test "without curl prefix" do
+      assert ~CURL(http://localhost) ==
+               %Req.Request{
+                 method: :get,
+                 url: URI.parse("http://localhost")
+               }
+    end
   end
 end

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -1,18 +1,40 @@
 defmodule CurlReqTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest CurlReq
   import CurlReq
 
-  test "works with base URL" do
-    assert "curl -H \"accept-encoding: gzip\" -H \"user-agent: req/0.4.14\" -X GET https://catfact.ninja/fact" ==
-             Req.new(url: "/fact", base_url: "https://catfact.ninja/")
-             |> CurlReq.to_curl()
+  describe "to_curl" do
+    test "works with base URL" do
+      assert "curl -H \"accept-encoding: gzip\" -H \"user-agent: req/0.4.14\" -X GET https://catfact.ninja/fact" ==
+               Req.new(url: "/fact", base_url: "https://catfact.ninja/")
+               |> CurlReq.to_curl()
+    end
+  end
 
-    ~CURL(curl -H "user-agent: req/0.4.14" -X GET https://catfact.ninja/fact)
-    |> Req.request!()
+  describe "macro" do
+    test "single header" do
+      assert ~CURL(curl -H "user-agent: req/0.4.14" -X GET https://catfact.ninja/fact) ==
+               %Req.Request{
+                 method: :get,
+                 headers: %{"user-agent" => ["req/0.4.14"]},
+                 url: URI.parse("https://catfact.ninja/fact")
+               }
+    end
 
-    # ~CURL"""
-    # curl -H "accept-encoding: gzip" -H "authorization: Bearer 6e8f18e6-141b-4d12-8397-7e7791d92ed4:lon" -H "content-type: application/json" -H "user-agent: req/0.4.14" -d "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"3544VE\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to Aureliahof16, Utrecht, The Netherlands.\"}}],\"formId\":4318}" -X POST "https://130-RZU-897.mktorest.com/rest/v1/leads/submitForm.json"
-    # """
+    test "multiple headers with body" do
+      assert ~CURL(curl -H "accept-encoding: gzip" -H "authorization: Bearer 6e8f18e6-141b-4d12-8397-7e7791d92ed4:lon" -H "content-type: application/json" -H "user-agent: req/0.4.14" -d "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"3544VE\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to Aureliahof16, Utrecht, The Netherlands.\"}}],\"formId\":4318}" -X POST "https://130-RZU-897.mktorest.com/rest/v1/leads/submitForm.json") ==
+               %Req.Request{
+                 method: :post,
+                 url: URI.parse("https://130-RZU-897.mktorest.com/rest/v1/leads/submitForm.json"),
+                 headers: %{
+                   "accept-encoding" => ["gzip"],
+                   "authorization" => ["Bearer 6e8f18e6-141b-4d12-8397-7e7791d92ed4:lon"],
+                   "content-type" => ["application/json"],
+                   "user-agent" => ["req/0.4.14"]
+                 },
+                 body:
+                   "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"3544VE\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to Aureliahof16, Utrecht, The Netherlands.\"}}],\"formId\":4318}"
+               }
+    end
   end
 end


### PR DESCRIPTION
Instead of doing the manual parsing, my proposal is to use the native [`OptionParser`](https://hexdocs.pm/elixir/OptionParser.html) module. This makes adding more options trivial and reliable. I tried to keep the options as they were without adding more.

I also cleaned up the tests a bit, so we can test the sigil better.

I hope you find this a valuable addition