### PR TITLE
Handle multiple -d/--data flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Contributions are welcome! There are gaps in the library, and this is open sourc
 - [x] curl -X
 - [x] curl -d
 - [ ] curl -b
-- [x] curl long form options (--header, --body, etc)
+- [x] curl long form options (--header, --data, etc)
 - [ ] Req Plugin to log curl command (like `TeslaCurl`)
 
 ## How to contribute

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -3,7 +3,6 @@ defmodule CurlReq.Macro do
 
   # TODO: handle newlines
   # TODO: support -b (cookies)
-  # TODO: support multiple -d
 
   def parse(command) do
     command =
@@ -15,8 +14,8 @@ defmodule CurlReq.Macro do
       command
       |> OptionParser.split()
       |> OptionParser.parse(
-        strict: [header: :keep, request: :string, body: :string],
-        aliases: [H: :header, X: :request, d: :body]
+        strict: [header: :keep, request: :string, data: :keep],
+        aliases: [H: :header, X: :request, d: :data]
       )
 
     url = String.trim(url)
@@ -56,7 +55,12 @@ defmodule CurlReq.Macro do
   end
 
   defp add_body(req, options) do
-    body = Keyword.get(options, :body)
+    body =
+      case Keyword.get_values(options, :data) do
+        [] -> nil
+        data -> Enum.join(data, "&")
+      end
+
     Req.merge(req, body: body)
   end
 end

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -44,5 +44,13 @@ defmodule CurlReqTest do
                  url: URI.parse("http://localhost")
                }
     end
+
+    test "multiple data flags" do
+      assert ~CURL(curl http://example.com -d name=foo -d mail=bar) ==
+               %Req.Request{
+                 url: URI.parse("http://example.com"),
+                 body: "name=foo&mail=bar"
+               }
+    end
   end
 end


### PR DESCRIPTION
The long form flag was corrected to `--data` instead of `--body`.
It now joins the string with an `&` as described in the man pages.