### PR TITLE
Multiline Curl commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.98.5
+- Multiline Curl commands are now supported
 
 ## 0.98.4
 - Add CurlReq.Plugin

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The docs can be found at <https://hexdocs.pm/curl_req>.
 
 Contributions are welcome! There are gaps in the library, and this is open source, so let's work together to fill them!
 
-- [ ] ~CURL sigil handles newlines
+- [x] ~CURL sigil handles newlines
 - [x] curl [url]
 - [x] curl -H
 - [x] curl -X

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -1,8 +1,6 @@
 defmodule CurlReq.Macro do
   @moduledoc false
 
-  # TODO: handle newlines
-
   @spec parse(String.t()) :: Req.Request.t()
   def parse(command) do
     command =

--- a/test/curl_req/macro_test.exs
+++ b/test/curl_req/macro_test.exs
@@ -122,4 +122,39 @@ defmodule CurlReq.MacroTest do
                }
     end
   end
+
+  describe "newlines" do
+    test "sigil_CURL supports newlines" do
+      curl = ~CURL"""
+        curl -X POST \
+         --location \ 
+         https://example.com
+      """
+
+      assert curl == %Req.Request{
+               method: :post,
+               url: URI.parse("https://example.com"),
+               registered_options: MapSet.new([:redirect]),
+               options: %{redirect: true},
+               response_steps: [redirect: &Req.Steps.redirect/1]
+             }
+    end
+
+    test "from_curl supports newlines" do
+      curl =
+        from_curl("""
+          curl -X POST \
+           --location \ 
+           https://example.com
+        """)
+
+      assert curl == %Req.Request{
+               method: :post,
+               url: URI.parse("https://example.com"),
+               registered_options: MapSet.new([:redirect]),
+               options: %{redirect: true},
+               response_steps: [redirect: &Req.Steps.redirect/1]
+             }
+    end
+  end
 end


### PR DESCRIPTION
This PR parses the URI from the rest of the `OptionParser`. This makes it more stable and reliable and supports newlines because they get filtered out