### PR TITLE
Support short and long flags in `to_curl/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.98.5
 - Multiline Curl commands are now supported
+- `to_curl/2` now supports short and long argument flag generation
 
 ## 0.98.4
 - Add CurlReq.Plugin

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -32,6 +32,17 @@ defmodule CurlReqTest do
                "curl #{default_header()} -I http://example.com"
     end
 
+    test "long flags" do
+      assert Req.new(
+               url: "http://example.com",
+               method: :head,
+               redirect: true,
+               headers: %{"cookie" => ["name1=value1"], "content-type" => ["application/json"]}
+             )
+             |> CurlReq.to_curl(flags: :long) ==
+               "curl --header \"accept-encoding: gzip\" --header \"content-type: application/json\" --header \"user-agent: req/#{@req_version}\" --cookie \"name1=value1\" --head --location http://example.com"
+    end
+
     test "formdata flags get set with correct headers and body" do
       assert Req.new(url: "http://example.com", form: [key1: "value1", key2: "value2"])
              |> CurlReq.to_curl() ==


### PR DESCRIPTION
Closes #8 
