### PR TITLE
Add more auths and fine tuned run_steps

### DIFF
--- a/lib/curl_req.ex
+++ b/lib/curl_req.ex
@@ -138,9 +138,6 @@ defmodule CurlReq do
 
           {:netrc, filepath} ->
             [netrc_file_flag(flag_style), filepath]
-
-          _ ->
-            []
         end
       else
         _ ->

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -20,7 +20,8 @@ defmodule CurlReq.Macro do
           head: :boolean,
           form: :keep,
           location: :boolean,
-          user: :string
+          user: :string,
+          netrc: :boolean
         ],
         aliases: [
           H: :header,
@@ -30,7 +31,8 @@ defmodule CurlReq.Macro do
           I: :head,
           F: :form,
           L: :location,
-          u: :user
+          u: :user,
+          n: :netrc
         ]
       )
 
@@ -72,6 +74,12 @@ defmodule CurlReq.Macro do
             |> Req.Request.register_options([:auth])
             |> Req.Request.prepend_request_steps(auth: &Req.Steps.auth/1)
             |> Req.merge(auth: {:bearer, token})
+
+          {"authorization", "Basic " <> token} ->
+            req
+            |> Req.Request.register_options([:auth])
+            |> Req.Request.prepend_request_steps(auth: &Req.Steps.auth/1)
+            |> Req.merge(auth: {:basic, token})
 
           _ ->
             Req.Request.put_header(req, key, value)


### PR DESCRIPTION
Add support for more auth schemes into their Curl counterparts (eg `-n` for `:netrc`).

This requires that the `auth` step from `Req` doesn't run, since it actually validates the netrc file and inserts the basic auth from it. It also will base64 encode Basic auth, and cause there to be duplicates between the headers and auth fields of the `Req` struct. So I added options `:except` and `:only` to the `run_steps` function to have more fine-tuned control over which steps are run.