### PR TITLE
dk-handle_data_raw

### DIFF
--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -101,7 +101,7 @@ defmodule CurlReq.Macro do
 
   defp add_body(req, options) do
     body =
-      [:data, :data_raw, :data_ascii]
+      [:data, :data_ascii, :data_raw]
       |> Enum.reduce([], fn key, acc ->
         case Keyword.get_values(options, key) do
           [] -> acc

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -105,7 +105,7 @@ defmodule CurlReq.Macro do
       |> Enum.reduce([], fn key, acc ->
         case Keyword.get_values(options, key) do
           [] -> acc
-          ["$" <> data] when key == :data_raw -> acc ++ [data]
+          ["$" <> data] -> acc ++ [data]
           values -> acc ++ values
         end
       end)

--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -18,6 +18,8 @@ defmodule CurlReq.Macro do
           header: :keep,
           request: :string,
           data: :keep,
+          data_raw: :keep,
+          data_ascii: :keep,
           cookie: :string,
           head: :boolean,
           form: :keep,
@@ -99,7 +101,15 @@ defmodule CurlReq.Macro do
 
   defp add_body(req, options) do
     body =
-      case Keyword.get_values(options, :data) do
+      [:data, :data_raw, :data_ascii]
+      |> Enum.reduce([], fn key, acc ->
+        case Keyword.get_values(options, key) do
+          [] -> acc
+          ["$" <> data] when key == :data_raw -> acc ++ [data]
+          values -> acc ++ values
+        end
+      end)
+      |> case do
         [] -> nil
         data -> Enum.join(data, "&")
       end

--- a/test/curl_req/macro_test.exs
+++ b/test/curl_req/macro_test.exs
@@ -90,6 +90,50 @@ defmodule CurlReq.MacroTest do
                }
     end
 
+    test "data raw" do
+      assert ~CURL"""
+             curl 'https://example.com/graphql' \
+             -X POST \
+             -H 'Accept: application/graphql-response+json'\
+             --data-raw '{"operationName":"get","query":"query get {name}"}'
+             """ ==
+               %Req.Request{
+                 method: :post,
+                 url: URI.parse("https://example.com/graphql"),
+                 headers: %{"accept" => ["application/graphql-response+json"]},
+                 body: "{\"operationName\":\"get\",\"query\":\"query get {name}\"}",
+                 options: %{},
+                 halted: false,
+                 adapter: &Req.Steps.run_finch/1,
+                 request_steps: [],
+                 response_steps: [],
+                 error_steps: [],
+                 private: %{}
+               }
+    end
+
+    test "data raw with ansii escape" do
+      assert ~CURL"""
+             curl 'https://example.com/employees/107'\
+             -X PATCH\
+             -H 'Accept: application/vnd.api+json'\
+             --data-raw $'{"data":{"attributes":{"first-name":"Adam"}}}'
+             """ ==
+               %Req.Request{
+                 method: :patch,
+                 url: URI.parse("https://example.com/employees/107"),
+                 headers: %{"accept" => ["application/vnd.api+json"]},
+                 body: "{\"data\":{\"attributes\":{\"first-name\":\"Adam\"}}}",
+                 options: %{},
+                 halted: false,
+                 adapter: &Req.Steps.run_finch/1,
+                 request_steps: [],
+                 response_steps: [],
+                 error_steps: [],
+                 private: %{}
+               }
+    end
+
     test "auth" do
       assert ~CURL(curl http://example.com -u user:pass) ==
                %Req.Request{
@@ -167,7 +211,7 @@ defmodule CurlReq.MacroTest do
     test "sigil_CURL supports newlines" do
       curl = ~CURL"""
         curl -X POST \
-         --location \ 
+         --location \
          https://example.com
       """
 
@@ -184,7 +228,7 @@ defmodule CurlReq.MacroTest do
       curl =
         from_curl("""
           curl -X POST \
-           --location \ 
+           --location \
            https://example.com
         """)
 


### PR DESCRIPTION
Hey @derekkraan 
I often copy curl requests from the browser. 
In my case the data is always under the key `data-raw` which does the same as --data but does not support `@` which is reading from file or stdin which is not supported currently in curl_req so I think all should be handled identical. 

[From the docs:](https://curl.se/docs/manpage.html)
> --data-ascii <data>
(HTTP) This option is just an alias for [-d, --data](https://curl.se/docs/manpage.html#-d).

> --data-raw <data>
(HTTP) Post data similarly to [-d, --data](https://curl.se/docs/manpage.html#-d) but without the special interpretation of the @ character.

Another thing I spotted that [some requests have dollar sign](https://unix.stackexchange.com/questions/115612/understanding-two-flags-and-a-dollar-sign-in-a-curl-command) in the beginning - this is handled by the shell and has to be stripped