### PR TITLE
Raise on unknown/invalid curl flags

### DIFF
--- a/lib/curl_req/macro.ex
+++ b/lib/curl_req/macro.ex
@@ -10,7 +10,7 @@ defmodule CurlReq.Macro do
       |> String.replace("\\\n", " ")
       |> String.replace("\n", " ")
 
-    {options, rest, _invalid} =
+    {options, rest, invalid} =
       command
       |> OptionParser.split()
       |> OptionParser.parse(
@@ -38,6 +38,25 @@ defmodule CurlReq.Macro do
           u: :user
         ]
       )
+
+    if invalid != [] do
+      errors =
+        Enum.map(invalid, fn
+          {flag, nil} -> "Unknown #{inspect(flag)}"
+          {flag, value} -> "Invalid value #{inspect(value)} for #{inspect(flag)}"
+        end)
+        |> Enum.join("\n")
+
+      raise ArgumentError, """
+
+      Command: \'curl #{command}\"
+      Unsupported or invalid flag(s) encountered:
+
+      #{errors}
+
+      Please remove the unknown flags and open an issue at https://github.com/derekkraan/curl_req
+      """
+    end
 
     [url] =
       rest

--- a/test/curl_req/macro_test.exs
+++ b/test/curl_req/macro_test.exs
@@ -290,5 +290,11 @@ defmodule CurlReq.MacroTest do
                    }'
              """
     end
+
+    test "raises on unsupported flag" do
+      assert_raise ArgumentError, ~r/Unknown "--foo"/, fn ->
+        CurlReq.Macro.parse(~s(curl --foo https://example.com))
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #24 

We need to raise instead of just logging a warning because with an unknown flag we do not know if it is just a boolean flag or needs a value. But instead of just the stacktrace, we can explain why we fail at this stage and help guide the user.

Example:

`curl -k https://example.com` would work if we would know that it's a boolean flag but when we parse it the URI gets set as the value for "-k" and the URI itself will be empty.