### PR TITLE
User agent flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 0.100.0
 
-- Switch some flag positions in the generated cURL command
-- Some bugfixes regarding the constructed Req.Request struct when multiple request steps have to be set
+- [BREAKING]: Switch some flag positions in the generated cURL command
+- Some bugfixes regarding the constructed `Req.Request` struct when multiple request steps have to be set
 - [BREAKING]: From cURL to Req the body gets encoded in the specified encoding and set in the correct Req option
-- New `CurlReq.Request` module for an internal representation
+- [BREAKING]: User Agent is encoded in the user agent flag (`--user-agent`/`-A`) instead of a generic header ([#32](https://github.com/derekkraan/curl_req/pull/32))
+- New `CurlReq.Request` module for an internal representation of the HTTP request ([#29](https://github.com/derekkraan/curl_req/pull/29))
+- Add new supported flag: `--insecure`/`-k` ([#31](https://github.com/derekkraan/curl_req/pull/31))
 
 ## 0.99.0
 

--- a/lib/curl_req.ex
+++ b/lib/curl_req.ex
@@ -106,7 +106,7 @@ defmodule CurlReq do
 
       iex> Req.new(url: URI.parse("https://www.example.com"))
       ...> |> CurlReq.to_curl(flags: :long, flavor: :req)
-      ~S(curl --header "accept-encoding: gzip" --header "user-agent: req/#{@req_version}" --request GET https://www.example.com)
+      ~S(curl --header "accept-encoding: gzip" --user-agent "req/#{@req_version}" --request GET https://www.example.com)
 
       iex> Req.new(url: "https://www.example.com")
       ...> |> CurlReq.to_curl(run_steps: [except: [:compressed]])

--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -10,11 +10,11 @@ defmodule CurlReq.Req do
   def decode(%Req.Request{} = req, _opts \\ []) do
     request =
       %CurlReq.Request{}
+      |> CurlReq.Request.put_user_agent(:req)
       |> put_header(req)
       |> CurlReq.Request.put_auth(req.options[:auth])
       |> CurlReq.Request.put_redirect(req.options[:redirect])
       |> CurlReq.Request.put_compression(req.options[:compressed])
-      |> CurlReq.Request.put_user_agent(:req)
       |> CurlReq.Request.put_body(req.body)
       |> CurlReq.Request.put_url(req.url)
       |> CurlReq.Request.put_method(req.method)

--- a/lib/curl_req/request.ex
+++ b/lib/curl_req/request.ex
@@ -419,6 +419,10 @@ defmodule CurlReq.Request do
   @spec put_redirect(__MODULE__.t(), :req | :curl | String.t()) :: __MODULE__.t()
   def put_user_agent(%__MODULE{} = request, nil), do: request
 
+  def put_user_agent(%__MODULE{} = request, "req/" <> _) do
+    %{request | user_agent: :req}
+  end
+
   def put_user_agent(%__MODULE{} = request, user_agent)
       when user_agent in [:curl, :req] or is_binary(user_agent) do
     %{request | user_agent: user_agent}

--- a/lib/curl_req/request.ex
+++ b/lib/curl_req/request.ex
@@ -417,6 +417,8 @@ defmodule CurlReq.Request do
       "some user agent"
   """
   @spec put_redirect(__MODULE__.t(), :req | :curl | String.t()) :: __MODULE__.t()
+  def put_user_agent(%__MODULE{} = request, nil), do: request
+
   def put_user_agent(%__MODULE{} = request, user_agent)
       when user_agent in [:curl, :req] or is_binary(user_agent) do
     %{request | user_agent: user_agent}

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -220,7 +220,6 @@ defmodule CurlReqTest do
       assert ~CURL(curl -H "user-agent: req/0.4.14" -X GET https://example.com/fact) ==
                %Req.Request{
                  method: :get,
-                 headers: %{"user-agent" => ["req/0.4.14"]},
                  url: URI.parse("https://example.com/fact")
                }
     end
@@ -246,9 +245,6 @@ defmodule CurlReqTest do
                %Req.Request{
                  method: :post,
                  url: URI.parse("https://example.com/rest/v1/leads/submitForm.json"),
-                 headers: %{
-                   "user-agent" => ["req/0.4.14"]
-                 },
                  registered_options: MapSet.new([:compressed, :auth, :json]),
                  options: %{
                    compressed: true,

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -82,7 +82,7 @@ defmodule CurlReqTest do
     end
 
     test "req flavor with explicit headers" do
-      assert ~s|curl -H "accept-encoding: gzip" -H "user-agent: req/#{req_version()}" -X GET https://example.com| ==
+      assert ~s|curl -H "accept-encoding: gzip" -A "req/#{req_version()}" -X GET https://example.com| ==
                Req.new(url: "https://example.com")
                |> CurlReq.to_curl(flavor: :req)
     end
@@ -196,6 +196,22 @@ defmodule CurlReqTest do
                  }
                }
                |> CurlReq.to_curl()
+    end
+
+    test "user agent flag" do
+      assert ~s(curl --compressed -A "some_user_agent/0.1.0" -X GET http://example.com) ==
+               Req.new(
+                 url: "http://example.com",
+                 headers: %{"user-agent" => ["some_user_agent/0.1.0"]}
+               )
+               |> CurlReq.to_curl()
+
+      assert ~s(curl --compressed --user-agent "some_user_agent/0.1.0" --request GET http://example.com) ==
+               Req.new(
+                 url: "http://example.com",
+                 headers: %{"user-agent" => ["some_user_agent/0.1.0"]}
+               )
+               |> CurlReq.to_curl(flags: :long)
     end
   end
 
@@ -513,6 +529,20 @@ defmodule CurlReqTest do
                      transport_opts: [verify: :verify_none]
                    ]
                  }
+               }
+    end
+
+    test "user agent flag" do
+      assert ~CURL(curl -A "some_user_agent/0.1.0" http://example.com) ==
+               %Req.Request{
+                 url: URI.parse("http://example.com"),
+                 headers: %{"user-agent" => ["some_user_agent/0.1.0"]}
+               }
+
+      assert ~CURL(curl --user-agent "some_user_agent/0.1.0" http://example.com) ==
+               %Req.Request{
+                 url: URI.parse("http://example.com"),
+                 headers: %{"user-agent" => ["some_user_agent/0.1.0"]}
                }
     end
   end


### PR DESCRIPTION
Closes #20 

Another breaking change for `0.100.0` because we can now encode the user agent in the associated flag instead of the generic header