### PR TITLE
Add more common flags

### DIFF
--- a/lib/curl_req/curl.ex
+++ b/lib/curl_req/curl.ex
@@ -22,7 +22,12 @@ defmodule CurlReq.Curl do
     netrc: :boolean,
     netrc_file: :string,
     insecure: :boolean,
-    user_agent: :string
+    user_agent: :string,
+    fail: :boolean,
+    silent: :boolean,
+    show_error: :boolean,
+    output: :string,
+    remote_name: :boolean
   ]
 
   @aliases [
@@ -38,7 +43,12 @@ defmodule CurlReq.Curl do
     U: :proxy_user,
     n: :netrc,
     k: :insecure,
-    A: :user_agent
+    A: :user_agent,
+    f: :fail,
+    s: :silent,
+    S: :show_error,
+    o: :output,
+    O: :remote_name
   ]
 
   @doc """

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -627,6 +627,16 @@ defmodule CurlReqTest do
              """
     end
 
+    test "unused flags get ignored" do
+      # we don't need an assertion because if we couldn't parse the flag we would throw an exception and the test would fail
+      CurlReq.Curl.decode(~s(curl -o "somefile" https://example.com))
+      CurlReq.Curl.decode(~s(curl -O https://example.com))
+      CurlReq.Curl.decode(~s(curl -s https://example.com))
+      CurlReq.Curl.decode(~s(curl -S https://example.com))
+      CurlReq.Curl.decode(~s(curl -f https://example.com))
+      CurlReq.Curl.decode(~s(curl -fsS https://example.com))
+    end
+
     test "raises on unsupported flag" do
       assert_raise ArgumentError, ~r/Unknown "--foo"/, fn ->
         CurlReq.Curl.decode(~s(curl --foo https://example.com))


### PR DESCRIPTION
To make parsing more stable because the flags are often used. We currently don't use them because they are describing the runtime behaviour and not how the request itself is built/configured. 