### PR TITLE
Default to HTTP when no scheme is declared in url

### DIFF
--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -216,6 +216,22 @@ defmodule CurlReqTest do
   end
 
   describe "from_curl" do
+    test "no scheme in url defaults to http" do
+      assert ~CURL(curl example.com/fact) ==
+               %Req.Request{
+                 method: :get,
+                 url: URI.parse("http://example.com/fact")
+               }
+    end
+
+    test "wrong scheme raises error" do
+      assert_raise(
+        ArgumentError,
+        "Unsupported scheme ftp for URL in ftp://example.com/fact",
+        fn -> CurlReq.from_curl(~s"curl ftp://example.com/fact") end
+      )
+    end
+
     test "single header" do
       assert ~CURL(curl -H "user-agent: req/0.4.14" -X GET https://example.com/fact) ==
                %Req.Request{
@@ -483,7 +499,7 @@ defmodule CurlReqTest do
     test "proxy raises on non http scheme uri" do
       assert_raise(
         ArgumentError,
-        "Unsupported scheme ssh for proxy in ssh://my.proxy.com:22225",
+        "Unsupported scheme ssh for URL in ssh://my.proxy.com:22225",
         fn ->
           CurlReq.Curl.decode("curl --proxy ssh://my.proxy.com:22225 http://example.com")
         end


### PR DESCRIPTION
```
curl example.com
```

This command would've failed to parse, because we required an explicit scheme like

```
curl http://example.com
```

but curl accepts this and sets http by default, so we do the same and reuse the logic from the proxy parsing

> As a convenience, curl also allows users to leave out the scheme part from URLs. Then it guesses which protocol to use based on the first part of the hostname. That guessing is basic, as it just checks if the first part of the hostname matches one of a set of protocols, and assumes you meant to use that protocol. This heuristic is based on the fact that servers traditionally used to be named like that. The protocols that are detected this way are FTP, DICT, LDAP, IMAP, SMTP and POP3. Any other hostname in a scheme-less URL makes curl default to HTTP.

Because we convert to Req we don't need the heuristics to parse to anything other than HTTP