### PR TITLE
Default to form encoding for cURL

### DIFF
--- a/lib/curl_req.ex
+++ b/lib/curl_req.ex
@@ -145,9 +145,6 @@ defmodule CurlReq do
       iex> CurlReq.from_curl("curl https://www.example.com")
       %Req.Request{method: :get, url: URI.parse("https://www.example.com")}
 
-      iex> CurlReq.from_curl(~s|curl -d "some data" https://example.com|)
-      %Req.Request{method: :get, body: "some data", url: URI.parse("https://example.com")}
-
       iex> CurlReq.from_curl("curl -I https://example.com")
       %Req.Request{method: :head, url: URI.parse("https://example.com")}
 
@@ -177,9 +174,6 @@ defmodule CurlReq do
 
       iex> ~CURL(curl "https://www.example.com")
       %Req.Request{method: :get, url: URI.parse("https://www.example.com")}
-
-      iex> ~CURL(curl -d "some data" "https://example.com")
-      %Req.Request{method: :get, body: "some data", url: URI.parse("https://example.com")}
 
       iex> ~CURL(curl -I "https://example.com")
       %Req.Request{method: :head, url: URI.parse("https://example.com")}

--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -89,21 +89,25 @@ defmodule CurlReq.Req do
       end
 
     req =
-      case request.encoding do
-        :raw ->
-          Req.merge(req, body: request.body)
+      if not is_nil(request.body) do
+        case request.encoding do
+          :raw ->
+            Req.merge(req, body: request.body)
 
-        :form ->
-          req
-          |> Req.Request.register_options([:form])
-          |> Req.Request.prepend_request_steps(encode_body: &Req.Steps.encode_body/1)
-          |> Req.merge(form: request.body)
+          :form ->
+            req
+            |> Req.Request.register_options([:form])
+            |> Req.Request.prepend_request_steps(encode_body: &Req.Steps.encode_body/1)
+            |> Req.merge(form: request.body)
 
-        :json ->
-          req
-          |> Req.Request.register_options([:json])
-          |> Req.Request.prepend_request_steps(encode_body: &Req.Steps.encode_body/1)
-          |> Req.merge(json: request.body)
+          :json ->
+            req
+            |> Req.Request.register_options([:json])
+            |> Req.Request.prepend_request_steps(encode_body: &Req.Steps.encode_body/1)
+            |> Req.merge(json: request.body)
+        end
+      else
+        req
       end
 
     req =

--- a/test/curl_req/request_test.exs
+++ b/test/curl_req/request_test.exs
@@ -1,4 +1,93 @@
 defmodule CurlReq.RequestTest do
   use ExUnit.Case, async: true
   doctest CurlReq.Request
+
+  alias CurlReq.Request
+  import CurlReq.Request
+
+  describe "put_body/2" do
+    test "decode form" do
+      request =
+        %Request{}
+        |> put_encoding(:form)
+        |> put_body("foo=bar")
+
+      assert %{"foo" => "bar"} = request.body
+    end
+
+    test "decode json" do
+      request =
+        %Request{}
+        |> put_encoding(:json)
+        |> put_body(~s({"foo":"bar"}))
+
+      assert %{"foo" => "bar"} = request.body
+    end
+  end
+
+  describe "put_encoding/2" do
+    test "raw to form" do
+      request =
+        %Request{}
+        |> put_encoding(:raw)
+        |> put_body("foo=bar")
+        |> put_encoding(:form)
+
+      assert %{"foo" => "bar"} = request.body
+    end
+
+    test "raw to json" do
+      request =
+        %Request{}
+        |> put_encoding(:raw)
+        |> put_body(~s({"foo":"bar"}))
+        |> put_encoding(:json)
+
+      assert %{"foo" => "bar"} = request.body
+    end
+
+    test "form to raw" do
+      request =
+        %Request{}
+        |> put_encoding(:form)
+        |> put_body(%{"foo" => "bar"})
+        |> put_encoding(:raw)
+
+      assert :raw == request.encoding
+      assert "foo=bar" == request.body
+    end
+
+    test "json to raw" do
+      request =
+        %Request{}
+        |> put_encoding(:json)
+        |> put_body(%{"foo" => "bar"})
+        |> put_encoding(:raw)
+
+      assert :raw == request.encoding
+      assert ~s({"foo":"bar"}) == request.body
+    end
+
+    test "json to form" do
+      request =
+        %Request{}
+        |> put_encoding(:form)
+        |> put_body(%{"foo" => "bar"})
+        |> put_encoding(:json)
+
+      assert %{"foo" => "bar"} = request.body
+    end
+
+    test "from and to same encoding is noop" do
+      request =
+        %Request{}
+        |> put_encoding(:form)
+        |> put_body(%{"foo" => "bar"})
+        |> put_encoding(:form)
+        |> put_encoding(:form)
+        |> put_encoding(:form)
+
+      assert %{"foo" => "bar"} = request.body
+    end
+  end
 end

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -55,7 +55,9 @@ defmodule CurlReqTest do
                headers: %{"cookie" => ["name1=value1"], "content-type" => ["application/json"]}
              )
              |> CurlReq.to_curl(flags: :long) ==
-               ~S|curl --compressed --header "content-type: application/json" --cookie "name1=value1" --location --head http://example.com|
+               ~S|curl --compressed --cookie "name1=value1" --location --head http://example.com|
+
+      # header get's removed because body is empty
     end
 
     test "formdata flags get set with correct headers and body" do
@@ -65,7 +67,7 @@ defmodule CurlReqTest do
     end
 
     test "works when body is iodata" do
-      assert "curl --compressed -d hello -X POST https://example.com/fact" ==
+      assert ~s|curl --compressed -H "content-type: text/plain" -d hello -X POST https://example.com/fact| ==
                Req.new(
                  method: :post,
                  url: "/fact",
@@ -240,6 +242,64 @@ defmodule CurlReqTest do
                }
     end
 
+    test "raw body" do
+      assert ~CURL(curl -d foo https://example.com) ==
+               %Req.Request{
+                 options: %{form: %{"foo" => ""}},
+                 registered_options: MapSet.new([:form]),
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1],
+                 url: URI.parse("https://example.com"),
+                 method: :post
+               }
+    end
+
+    test "form body" do
+      assert ~CURL(curl -d foo=bar https://example.com) ==
+               %Req.Request{
+                 options: %{form: %{"foo" => "bar"}},
+                 registered_options: MapSet.new([:form]),
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1],
+                 url: URI.parse("https://example.com"),
+                 method: :post
+               }
+
+      assert ~CURL(curl -d foo=bar&baz=qux https://example.com) ==
+               %Req.Request{
+                 options: %{form: %{"foo" => "bar", "baz" => "qux"}},
+                 registered_options: MapSet.new([:form]),
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1],
+                 url: URI.parse("https://example.com"),
+                 method: :post
+               }
+    end
+
+    test "form body with multiple data flags" do
+      assert ~CURL(curl http://example.com -d name=foo -d mail=bar) ==
+               %Req.Request{
+                 options: %{form: %{"name" => "foo", "mail" => "bar"}},
+                 registered_options: MapSet.new([:form]),
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1],
+                 url: URI.parse("http://example.com"),
+                 method: :post
+               }
+    end
+
+    test "json body" do
+      assert ~CURL(curl -H "content-type: application/json" -d "{\"foo\": \"bar\"}" https://example.com) ==
+               %Req.Request{
+                 options: %{json: %{"foo" => "bar"}},
+                 registered_options: MapSet.new([:json]),
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1],
+                 url: URI.parse("https://example.com"),
+                 method: :post
+               }
+    end
+
     test "multiple headers with body" do
       assert ~CURL(curl -H "accept-encoding: gzip" -H "authorization: Bearer 6e8f18e6-141b-4d12-8397-7e7791d92ed4:lon" -H "content-type: application/json" -H "user-agent: req/0.4.14" -d "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"1234ZZ\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to The Netherlands.\"}}],\"formId\":4318}" -X POST "https://example.com/rest/v1/leads/submitForm.json") ==
                %Req.Request{
@@ -287,14 +347,6 @@ defmodule CurlReqTest do
                }
     end
 
-    test "multiple data flags" do
-      assert ~CURL(curl http://example.com -d name=foo -d mail=bar) ==
-               %Req.Request{
-                 url: URI.parse("http://example.com"),
-                 body: "name=foo&mail=bar"
-               }
-    end
-
     test "cookie" do
       assert ~CURL(http://example.com -b "name1=value1") ==
                %Req.Request{
@@ -326,20 +378,17 @@ defmodule CurlReqTest do
              curl 'https://example.com/graphql' \
              -X POST \
              -H 'Accept: application/graphql-response+json'\
+             -H 'Content-Type: application/json' \
              --data-raw '{"operationName":"get","query":"query get {name}"}'
              """ ==
                %Req.Request{
                  method: :post,
                  url: URI.parse("https://example.com/graphql"),
                  headers: %{"accept" => ["application/graphql-response+json"]},
-                 body: "{\"operationName\":\"get\",\"query\":\"query get {name}\"}",
-                 options: %{},
-                 halted: false,
-                 adapter: &Req.Steps.run_finch/1,
-                 request_steps: [],
-                 response_steps: [],
-                 error_steps: [],
-                 private: %{}
+                 registered_options: MapSet.new([:json]),
+                 options: %{json: %{"operationName" => "get", "query" => "query get {name}"}},
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1]
                }
     end
 
@@ -347,6 +396,7 @@ defmodule CurlReqTest do
       assert ~CURL"""
              curl 'https://example.com/employees/107'\
              -X PATCH\
+             -H 'Content-Type: application/json' \
              -H 'Accept: application/vnd.api+json'\
              --data-raw $'{"data":{"attributes":{"first-name":"Adam"}}}'
              """ ==
@@ -354,14 +404,10 @@ defmodule CurlReqTest do
                  method: :patch,
                  url: URI.parse("https://example.com/employees/107"),
                  headers: %{"accept" => ["application/vnd.api+json"]},
-                 body: "{\"data\":{\"attributes\":{\"first-name\":\"Adam\"}}}",
-                 options: %{},
-                 halted: false,
-                 adapter: &Req.Steps.run_finch/1,
-                 request_steps: [],
-                 response_steps: [],
-                 error_steps: [],
-                 private: %{}
+                 registered_options: MapSet.new([:json]),
+                 options: %{json: %{"data" => %{"attributes" => %{"first-name" => "Adam"}}}},
+                 current_request_steps: [:encode_body],
+                 request_steps: [encode_body: &Req.Steps.encode_body/1]
                }
     end
 


### PR DESCRIPTION
Starting with this knowledge

> The curl -d (or --data) command line argument tells Curl to send the passed data to the server in the body of the HTTP message. When you pass data to Curl with the -d command line argument, Curl, by default, sends the data to the server in the Content-Type: application/x-www-form-urlencoded format. To send data in a different format, you must specify the correct content type with the -H command line argument. The Content-Type request header is required for servers to correctly interpret and process the data in the POST message body.

i had to change the encoding/body handling and improved some test cases

- by default we set the encoding to `form` when parsing the curl command
- set method `post` when data ist specified in curl
- set content-type header only when body is not nil
- set `text/plain` content-type when body is set in Req because curl defaults to `application/x-www-urlencoded`
- use `URI.decode_query/1` instead of handwritten parsing of formdata