### PR TITLE
Fix parsing of header paramters for all headers

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,4 @@
+alias CurlReq.Request
+
+import CurlReq
+import CurlReq.Request

--- a/lib/curl_req/curl.ex
+++ b/lib/curl_req/curl.ex
@@ -286,7 +286,7 @@ defmodule CurlReq.Curl do
     headers =
       for {key, values} <- request.headers, reduce: [] do
         headers ->
-          [headers, header_flag(flag_style, [key, ": ", Enum.intersperse(values, ";")])]
+          [headers, header_flag(flag_style, [key, ": ", Enum.intersperse(values, "; ")])]
       end
 
     headers =

--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -76,11 +76,6 @@ defmodule CurlReq.Req do
       |> Req.merge(url: request.url)
       |> Req.merge(method: request.method)
 
-    cookies =
-      request.cookies
-      |> Enum.map(fn {key, val} -> "#{key}=#{val}" end)
-      |> Enum.join(";")
-
     req =
       case request.user_agent do
         :req -> req
@@ -151,12 +146,13 @@ defmodule CurlReq.Req do
         req -> Req.Request.put_header(req, key, values)
       end
 
-    req =
-      if cookies != "" do
-        Req.Request.put_header(req, "cookie", cookies)
-      else
-        req
-      end
+    cookies =
+      request.cookies
+      |> Enum.map(fn {key, val} ->
+        IO.iodata_to_binary([key, "=", val])
+      end)
+
+    req = if cookies != [], do: Req.Request.put_header(req, "cookie", cookies), else: req
 
     proxy =
       if request.proxy do

--- a/lib/curl_req/request.ex
+++ b/lib/curl_req/request.ex
@@ -103,8 +103,8 @@ defmodule CurlReq.Request do
       {"user-agent", [user_agent | _]} ->
         put_user_agent(request, user_agent)
 
-      {"cookie", [cookies | _]} ->
-        for cookie <- String.split(cookies, ";"), reduce: request do
+      {"cookie", cookies} ->
+        for cookie <- cookies, reduce: request do
           request ->
             [key, value] = String.split(cookie, "=")
             put_cookie(request, key, value)

--- a/lib/curl_req/request.ex
+++ b/lib/curl_req/request.ex
@@ -71,13 +71,14 @@ defmodule CurlReq.Request do
       {:bearer, "foobar"}
   """
   @spec put_header(__MODULE__.t(), String.t(), String.t() | [String.t()]) :: __MODULE__.t()
-  def put_header(%__MODULE__{} = request, key, [val]) do
+  def put_header(%__MODULE__{} = request, key, val) when is_binary(val) do
+    key = String.downcase(key) |> String.trim()
+    val = String.split(val, ";", trim: true) |> Enum.map(&String.trim/1)
     put_header(request, key, val)
   end
 
-  def put_header(%__MODULE__{} = request, key, val) when is_binary(val) do
+  def put_header(%__MODULE__{} = request, key, val) when is_list(val) do
     key = String.downcase(key) |> String.trim()
-    val = String.split(val, ";", trim: true)
 
     case {key, val} do
       {"authorization", ["Bearer " <> token | _]} ->

--- a/lib/curl_req/request.ex
+++ b/lib/curl_req/request.ex
@@ -183,10 +183,7 @@ defmodule CurlReq.Request do
   defp decode_json(json) when is_map(json), do: json
 
   defp decode_json(input) when is_binary(input) or is_list(input) do
-    case Jason.decode(input) do
-      {:ok, json} -> json
-      _ -> %{}
-    end
+    Jason.decode!(input)
   end
 
   defp decode_form(nil), do: nil

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -348,6 +348,18 @@ defmodule CurlReqTest do
                }
     end
 
+    test "complex cookie" do
+      request =
+        ~CURL(curl --header 'Cookie: TealeafAkaSid=JA-JSAXRCLjKYhjV9IXTzYUbcV1Lnhqf; sapphire=1; visitorId=0184E4601D5A020183FFBB133 80347CE; GuestLocation=33196|25.660|-80.440|FL|US' -X GET https://example.com)
+
+      cookies = request.headers["cookie"]
+
+      assert "TealeafAkaSid=JA-JSAXRCLjKYhjV9IXTzYUbcV1Lnhqf" in cookies
+      assert "sapphire=1" in cookies
+      assert "visitorId=0184E4601D5A020183FFBB133 80347CE" in cookies
+      assert "GuestLocation=33196|25.660|-80.440|FL|US" in cookies
+    end
+
     test "multiple headers with body" do
       assert ~CURL(curl -H "accept-encoding: gzip" -H "authorization: Bearer 6e8f18e6-141b-4d12-8397-7e7791d92ed4:lon" -H "content-type: application/json" -H "user-agent: req/0.4.14" -d "{\"input\":[{\"leadFormFields\":{\"Company\":\"k\",\"Country\":\"DZ\",\"Email\":\"k\",\"FirstName\":\"k\",\"Industry\":\"CTO\",\"LastName\":\"k\",\"Phone\":\"k\",\"PostalCode\":\"1234ZZ\",\"jobspecialty\":\"engineer\",\"message\":\"I would like to know if Roche delivers to The Netherlands.\"}}],\"formId\":4318}" -X POST "https://example.com/rest/v1/leads/submitForm.json") ==
                %Req.Request{
@@ -405,7 +417,7 @@ defmodule CurlReqTest do
       assert ~CURL(http://example.com -b "name1=value1; name2=value2") ==
                %Req.Request{
                  url: URI.parse("http://example.com"),
-                 headers: %{"cookie" => ["name1=value1;name2=value2"]}
+                 headers: %{"cookie" => ["name1=value1", "name2=value2"]}
                }
     end
 


### PR DESCRIPTION
A requeset with

```
curl https:example.com -H 'Content-Type: application/json; charset=utf-8'
```

would've failed because we didn't pattern match on the header with parameters. This is now fixed. We also raise if we can't parse the json instead of a fallback to an empty map. This should make it more transparent to the user because the request would've failed anyway