### PR TITLE
Create a fully formed `Req.Request` with `Req.new/0`

### DIFF
--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -72,7 +72,7 @@ defmodule CurlReq.Req do
   @spec encode(CurlReq.Request.t()) :: Req.Request.t()
   def encode(%CurlReq.Request{} = request, _opts \\ []) do
     req =
-      %Req.Request{}
+      Req.new()
       |> Req.merge(url: request.url)
       |> Req.merge(method: request.method)
 


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/derekkraan/curl_req/issues/51 but it breaks half of the tests because you assert them with e.g. `curl == %Req.Request{...}` everywhere. I ran the tests with Elixir 1.18 and this type of comparison lead to *a lot* of type warnings too :D Let me know if you want me to fix the tests :)