### PR TITLE
Use `Req.new/0` instead of `%Req.Request{}`

### DIFF
--- a/lib/curl_req.ex
+++ b/lib/curl_req.ex
@@ -142,30 +142,23 @@ defmodule CurlReq do
 
   ## Examples
 
-      iex> CurlReq.from_curl("curl https://www.example.com")
-      %Req.Request{
-        method: :get, 
-        url: URI.parse("https://www.example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = CurlReq.from_curl("curl https://www.example.com")
+      iex> req.method
+      :get
+      iex> req.url
+      URI.parse("https://www.example.com")
 
-      iex> CurlReq.from_curl("curl -I https://example.com")
-      %Req.Request{
-        method: :head, 
-        url: URI.parse("https://example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = CurlReq.from_curl("curl -I https://example.com")
+      iex> req.method
+      :head
+      iex> req.url
+      URI.parse("https://example.com")
 
-      iex> CurlReq.from_curl("curl -b cookie_key=cookie_val https://example.com")
-      %Req.Request{
-        method: :get, 
-        headers: %{"cookie" => ["cookie_key=cookie_val"]}, 
-        url: URI.parse("https://example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = CurlReq.from_curl("curl -b cookie_key=cookie_val https://example.com")
+      iex> req.method
+      :get
+      iex> Req.Request.get_header(req, "cookie")
+      ["cookie_key=cookie_val"]
   """
   @doc since: "0.98.4"
 
@@ -188,30 +181,23 @@ defmodule CurlReq do
 
   ## Examples
 
-      iex> ~CURL(curl "https://www.example.com")
-      %Req.Request{
-        method: :get, 
-        url: URI.parse("https://www.example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = ~CURL(curl "https://www.example.com")
+      iex> req.method
+      :get
+      iex> req.url
+      URI.parse("https://www.example.com")
 
-      iex> ~CURL(curl -I "https://example.com")
-      %Req.Request{
-        method: :head, 
-        url: URI.parse("https://example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = ~CURL(curl -I "https://example.com")
+      iex> req.method
+      :head
+      iex> req.url
+      URI.parse("https://example.com")
 
-      iex> ~CURL(curl -b "cookie_key=cookie_val" "https://example.com")
-      %Req.Request{
-        method: :get, 
-        headers: %{"cookie" => ["cookie_key=cookie_val"]}, 
-        url: URI.parse("https://example.com"), 
-        registered_options: MapSet.new([:connect_options]), 
-        options: %{connect_options: [protocols: [:http1, :http2]]}
-      }
+      iex> req = ~CURL(curl -b "cookie_key=cookie_val" "https://example.com")
+      iex> req.method
+      :get
+      iex> Req.Request.get_header(req, "cookie")
+      ["cookie_key=cookie_val"]
   """
   defmacro sigil_CURL(curl_command, modifiers)
 

--- a/lib/curl_req/curl.ex
+++ b/lib/curl_req/curl.ex
@@ -145,6 +145,8 @@ defmodule CurlReq.Curl do
     %CurlReq.Request{}
     |> CurlReq.Request.put_url(url)
     |> CurlReq.Request.put_encoding(:form)
+    |> CurlReq.Request.put_compression(false)
+    |> CurlReq.Request.put_redirect(false)
     |> add_header(options)
     |> add_body(options)
     |> add_cookie(options)

--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -138,6 +138,9 @@ defmodule CurlReq.Req do
       case request.compression do
         :none ->
           req
+          |> Req.Request.register_options([:compressed])
+          |> Req.Request.prepend_request_steps(compressed: &Req.Steps.compressed/1)
+          |> Req.merge(compressed: false)
 
         _ ->
           req
@@ -150,6 +153,9 @@ defmodule CurlReq.Req do
       case request.redirect do
         false ->
           req
+          |> Req.Request.register_options([:redirect])
+          |> Req.Request.prepend_response_steps(redirect: &Req.Steps.redirect/1)
+          |> Req.merge(redirect: false)
 
         _ ->
           req

--- a/lib/curl_req/req.ex
+++ b/lib/curl_req/req.ex
@@ -89,7 +89,7 @@ defmodule CurlReq.Req do
   @spec encode(CurlReq.Request.t()) :: Req.Request.t()
   def encode(%CurlReq.Request{} = request, _opts \\ []) do
     req =
-      %Req.Request{}
+      Req.new()
       |> Req.merge(url: request.url)
       |> Req.merge(method: request.method)
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule CurlReq.MixProject do
       package: package(),
       source_url: "https://github.com/derekkraan/curl_req",
       start_permanent: Mix.env() == :prod,
-      version: "0.100.0"
+      version: "0.100.0",
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -49,4 +50,7 @@ defmodule CurlReq.MixProject do
       maintainers: ["Derek Kraan", "Kevin Schweikert"]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/assertions.ex
+++ b/test/assertions.ex
@@ -1,0 +1,35 @@
+defmodule CurlReq.Assertions do
+  import ExUnit.Assertions
+
+  def assert_url(%Req.Request{} = req, uri) do
+    expected_uri =
+      cond do
+        is_binary(uri) ->
+          URI.parse(uri)
+
+        is_struct(uri, URI) ->
+          uri
+
+        true ->
+          flunk("Expected a string or %URI{} for the second argument, got: #{inspect(uri)}")
+      end
+
+    assert req.url == expected_uri,
+           "Expected request URI #{inspect(req.url)} to equal #{inspect(expected_uri)}"
+  end
+
+  def assert_redirect(%Req.Request{} = req) do
+    assert req.options[:redirect] == true,
+           "Expected redirect to be `true`, got: #{inspect(req.options[:redirect])}"
+  end
+
+  def assert_cookie(%Req.Request{} = req, cookie) when is_binary(cookie) do
+    case req.headers["cookie"] do
+      [cookies] ->
+        assert String.contains?(cookies, cookie)
+
+      other ->
+        flunk("Expected cookie header to contain #{cookie}, got: #{other}")
+    end
+  end
+end

--- a/test/assertions.ex
+++ b/test/assertions.ex
@@ -1,22 +1,12 @@
 defmodule CurlReq.Assertions do
   import ExUnit.Assertions
 
-  def assert_url(%Req.Request{} = req, uri) do
-    expected_uri =
-      cond do
-        is_binary(uri) ->
-          URI.parse(uri)
+  def assert_url(%Req.Request{} = req, uri) when is_binary(uri) do
+    assert_url(req, URI.parse(uri))
+  end
 
-        is_struct(uri, URI) ->
-          uri
-
-        true ->
-          flunk("Expected a string or %URI{} for the second argument, got: #{inspect(uri)}")
-      end
-
-    assert req.url == expected_uri,
-           "Expected request URI #{inspect(req.url)} to equal #{inspect(expected_uri)}"
-
+  def assert_url(%Req.Request{} = req, %URI{} = uri) do
+    assert req.url == uri, "Expected request URI #{inspect(req.url)} to equal #{inspect(uri)}"
     req
   end
 

--- a/test/assertions.ex
+++ b/test/assertions.ex
@@ -10,33 +10,40 @@ defmodule CurlReq.Assertions do
     req
   end
 
-  def assert_option(%Req.Request{} = req, option, value) do
-    assert Req.Request.fetch_option!(req, option) == value
+  def assert_option!(%Req.Request{} = req, option, value, opts \\ []) do
+    assert Req.Request.fetch_option!(req, option) == value, opts[:error] || []
     req
   end
 
-  def assert_redirect(%Req.Request{} = req) do
-    assert_option(req, :redirect, true)
+  def assert_option(%Req.Request{} = req, option, value, default \\ nil, opts \\ []) do
+    assert Req.Request.get_option(req, option, default) == value, opts[:error] || []
+    req
   end
 
-  def assert_compressed(%Req.Request{} = req) do
-    assert_option(req, :compressed, true)
+  def assert_redirect(%Req.Request{} = req, allowed? \\ true) do
+    assert_option(req, :redirect, allowed?, true, error: "Expected redirect set to #{allowed?}")
+  end
+
+  def assert_compressed(%Req.Request{} = req, allowed? \\ true) do
+    assert_option(req, :compressed, allowed?, true,
+      error: "Expected compressed set to #{allowed?}"
+    )
   end
 
   def assert_form(%Req.Request{} = req, form) do
-    assert_option(req, :form, form)
+    assert_option!(req, :form, form)
   end
 
   def assert_json(%Req.Request{} = req, json) do
-    assert_option(req, :json, json)
+    assert_option!(req, :json, json)
   end
 
   def assert_auth(%Req.Request{} = req, :bearer, token) do
-    assert_option(req, :auth, {:bearer, token})
+    assert_option!(req, :auth, {:bearer, token})
   end
 
   def assert_auth(%Req.Request{} = req, :basic, userinfo) do
-    assert_option(req, :auth, {:basic, userinfo})
+    assert_option!(req, :auth, {:basic, userinfo})
   end
 
   def assert_auth(%Req.Request{} = req, :proxy, userinfo) do

--- a/test/assertions.ex
+++ b/test/assertions.ex
@@ -16,20 +16,87 @@ defmodule CurlReq.Assertions do
 
     assert req.url == expected_uri,
            "Expected request URI #{inspect(req.url)} to equal #{inspect(expected_uri)}"
+
+    req
+  end
+
+  def assert_option(%Req.Request{} = req, option, value) do
+    assert Req.Request.fetch_option!(req, option) == value
+    req
   end
 
   def assert_redirect(%Req.Request{} = req) do
-    assert req.options[:redirect] == true,
-           "Expected redirect to be `true`, got: #{inspect(req.options[:redirect])}"
+    assert_option(req, :redirect, true)
+  end
+
+  def assert_compressed(%Req.Request{} = req) do
+    assert_option(req, :compressed, true)
+  end
+
+  def assert_form(%Req.Request{} = req, form) do
+    assert_option(req, :form, form)
+  end
+
+  def assert_json(%Req.Request{} = req, json) do
+    assert_option(req, :json, json)
+  end
+
+  def assert_auth(%Req.Request{} = req, :bearer, token) do
+    assert_option(req, :auth, {:bearer, token})
+  end
+
+  def assert_auth(%Req.Request{} = req, :basic, userinfo) do
+    assert_option(req, :auth, {:basic, userinfo})
+  end
+
+  def assert_auth(%Req.Request{} = req, :proxy, userinfo) do
+    connect_options = Req.Request.fetch_option!(req, :connect_options)
+    userinfo = Base.encode64(userinfo)
+
+    assert [{"proxy-authorization", "Basic " <> ^userinfo}] =
+             Keyword.fetch!(connect_options, :proxy_headers)
+  end
+
+  def assert_proxy(%Req.Request{} = req, scheme, host, port) when scheme in [:http, :https] do
+    connect_options = Req.Request.fetch_option!(req, :connect_options)
+    assert {^scheme, ^host, ^port, _} = Keyword.fetch!(connect_options, :proxy)
+    req
+  end
+
+  def assert_insecure(%Req.Request{} = req) do
+    connect_options = Req.Request.fetch_option!(req, :connect_options)
+    transport_opts = Keyword.fetch!(connect_options, :transport_opts)
+    assert :verify_none == Keyword.fetch!(transport_opts, :verify)
+    req
+  end
+
+  def assert_protocol(%Req.Request{} = req, protocol) when protocol in [:http1, :http2] do
+    connect_options = Req.Request.get_option(req, :connect_options, [])
+    protocols = Keyword.get(connect_options, :protocols, [:http1])
+    assert protocol in protocols
+    req
   end
 
   def assert_cookie(%Req.Request{} = req, cookie) when is_binary(cookie) do
     case req.headers["cookie"] do
       [cookies] ->
         assert String.contains?(cookies, cookie)
+        req
 
       other ->
         flunk("Expected cookie header to contain #{cookie}, got: #{other}")
     end
+  end
+
+  def assert_header(%Req.Request{} = req, name, value)
+      when is_binary(name) and is_list(value) do
+    assert Req.Request.get_header(req, name) == value
+    req
+  end
+
+  def assert_method(%Req.Request{} = req, method)
+      when method in [:get, :post, :put, :patch, :head] do
+    assert req.method == method
+    req
   end
 end

--- a/test/case.ex
+++ b/test/case.ex
@@ -1,0 +1,9 @@
+defmodule CurlReq.Case do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import CurlReq.Assertions
+    end
+  end
+end

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -1,5 +1,5 @@
 defmodule CurlReqTest do
-  use ExUnit.Case, async: true
+  use CurlReq.Case, async: true
 
   doctest CurlReq, import: true
 
@@ -416,12 +416,10 @@ defmodule CurlReqTest do
       request =
         ~CURL(curl --header 'Cookie: TealeafAkaSid=JA-JSAXRCLjKYhjV9IXTzYUbcV1Lnhqf; sapphire=1; visitorId=0184E4601D5A020183FFBB133 80347CE; GuestLocation=33196|25.660|-80.440|FL|US' -X GET https://example.com)
 
-      [cookie] = request.headers["cookie"]
-
-      assert String.contains?(cookie, "TealeafAkaSid=JA-JSAXRCLjKYhjV9IXTzYUbcV1Lnhqf")
-      assert String.contains?(cookie, "sapphire=1")
-      assert String.contains?(cookie, "visitorId=0184E4601D5A020183FFBB133 80347CE")
-      assert String.contains?(cookie, "GuestLocation=33196|25.660|-80.440|FL|US")
+      assert_cookie(request, "TealeafAkaSid=JA-JSAXRCLjKYhjV9IXTzYUbcV1Lnhqf")
+      assert_cookie(request, "sapphire=1")
+      assert_cookie(request, "visitorId=0184E4601D5A020183FFBB133 80347CE")
+      assert_cookie(request, "GuestLocation=33196|25.660|-80.440|FL|US")
     end
 
     test "multiple headers with body" do

--- a/test/curl_req_test.exs
+++ b/test/curl_req_test.exs
@@ -264,6 +264,13 @@ defmodule CurlReqTest do
       |> assert_url("http://example.com/fact")
     end
 
+    test "redirect and compression is false by default" do
+      ~CURL(curl example.com/fact)
+      |> assert_url("http://example.com/fact")
+      |> assert_redirect(false)
+      |> assert_compressed(false)
+    end
+
     test "wrong scheme raises error" do
       assert_raise(
         ArgumentError,
@@ -428,6 +435,9 @@ defmodule CurlReqTest do
 
     test "redirect" do
       ~CURL(curl -L http://example.com)
+      |> assert_redirect()
+
+      ~CURL(curl --location http://example.com)
       |> assert_redirect()
     end
 


### PR DESCRIPTION
Supersedes #52
Closes #51

The main change is still `Req.new/0` instead of `%Req.Request{}`

I've added some test assertion helpers to not have to match against the whole struct. This makes the test more concise and readable 